### PR TITLE
Improve reverse geocoding locality and administrative boundary resolution

### DIFF
--- a/builder/src/build_index.cpp
+++ b/builder/src/build_index.cpp
@@ -61,6 +61,13 @@ struct AdminPolygon {
     uint16_t country_code;
 };
 
+struct PlacePoint {
+    float lat;
+    float lng;
+    uint32_t name_id;
+    uint8_t place_type;
+};
+
 struct NodeCoord {
     float lat;
     float lng;
@@ -68,6 +75,13 @@ struct NodeCoord {
 
 static const uint32_t INTERIOR_FLAG = 0x80000000u;
 static const uint32_t ID_MASK = 0x7FFFFFFFu;
+
+enum PlaceType : uint8_t {
+    PLACE_SUBURB = 1,
+    PLACE_NEIGHBOURHOOD = 2,
+    PLACE_QUARTER = 3,
+    PLACE_CITY_DISTRICT = 4,
+};
 
 // --- String interning ---
 
@@ -115,6 +129,10 @@ static std::vector<AdminPolygon> admin_polygons;
 static std::vector<NodeCoord> admin_vertices;
 static std::unordered_map<uint64_t, std::vector<uint32_t>> cell_to_admin;
 
+// Place points
+static std::vector<PlacePoint> place_points;
+static std::unordered_map<uint64_t, std::vector<uint32_t>> cell_to_places;
+
 // --- S2 helpers ---
 
 static int kStreetCellLevel = 17;
@@ -141,6 +159,10 @@ static std::vector<S2CellId> cover_edge(double lat1, double lng1, double lat2, d
 
 static S2CellId point_to_cell(double lat, double lng) {
     return S2CellId(S2LatLng::FromDegrees(lat, lng)).parent(kStreetCellLevel);
+}
+
+static S2CellId point_to_admin_cell(double lat, double lng) {
+    return S2CellId(S2LatLng::FromDegrees(lat, lng)).parent(kAdminCellLevel);
 }
 
 // Returns pairs of (cell_id, is_interior)
@@ -357,6 +379,15 @@ static uint32_t parse_house_number(const char* s) {
     return n;
 }
 
+static uint8_t parse_place_type(const char* place) {
+    if (!place) return 0;
+    if (std::strcmp(place, "suburb") == 0) return PLACE_SUBURB;
+    if (std::strcmp(place, "neighbourhood") == 0) return PLACE_NEIGHBOURHOOD;
+    if (std::strcmp(place, "quarter") == 0) return PLACE_QUARTER;
+    if (std::strcmp(place, "city_district") == 0) return PLACE_CITY_DISTRICT;
+    return 0;
+}
+
 // --- Add an address point ---
 
 static uint64_t addr_count_total = 0;
@@ -377,6 +408,19 @@ static void add_addr_point(double lat, double lng, const char* housenumber, cons
     if (addr_count_total % 1000000 == 0) {
         std::cerr << "Collected " << addr_count_total / 1000000 << "M addresses..." << std::endl;
     }
+}
+
+static void add_place_point(double lat, double lng, const char* name, uint8_t place_type) {
+    uint32_t place_id = static_cast<uint32_t>(place_points.size());
+    place_points.push_back({
+        static_cast<float>(lat),
+        static_cast<float>(lng),
+        strings.intern(name),
+        place_type
+    });
+
+    S2CellId cell = point_to_admin_cell(lat, lng);
+    cell_to_places[cell.id()].push_back(place_id);
 }
 
 // --- Add an admin polygon ---
@@ -420,11 +464,18 @@ static void add_admin_polygon(const std::vector<std::pair<double,double>>& verti
 class BuildHandler : public osmium::handler::Handler {
 public:
     void node(const osmium::Node& node) {
+        if (!node.location().valid()) return;
+
+        const char* name = node.tags()["name"];
+        uint8_t place_type = parse_place_type(node.tags()["place"]);
+        if (name && place_type != 0) {
+            process_place(node, name, place_type);
+        }
+
         const char* housenumber = node.tags()["addr:housenumber"];
         if (!housenumber) return;
         const char* street = node.tags()["addr:street"];
         if (!street) return;
-        if (!node.location().valid()) return;
 
         add_addr_point(node.location().lat(), node.location().lon(), housenumber, street);
     }
@@ -517,12 +568,23 @@ public:
     uint64_t building_addr_count() const { return building_addr_count_; }
     uint64_t interp_count() const { return interp_count_; }
     uint64_t admin_count() const { return admin_count_; }
+    uint64_t place_count() const { return place_count_; }
 
 private:
     uint64_t way_count_ = 0;
     uint64_t building_addr_count_ = 0;
     uint64_t interp_count_ = 0;
     uint64_t admin_count_ = 0;
+    uint64_t place_count_ = 0;
+
+    void process_place(const osmium::Node& node, const char* name, uint8_t place_type) {
+        add_place_point(node.location().lat(), node.location().lon(), name, place_type);
+
+        place_count_++;
+        if (place_count_ % 100000 == 0) {
+            std::cerr << "Collected " << place_count_ / 1000 << "K place points..." << std::endl;
+        }
+    }
 
     void process_building_address(const osmium::Way& way, const char* housenumber, const char* street) {
         const auto& wnodes = way.nodes();
@@ -800,6 +862,9 @@ static void write_index(const std::string& output_dir) {
     write_cell_index(output_dir + "/admin_cells.bin", output_dir + "/admin_entries.bin", cell_to_admin);
     std::cerr << "admin index: " << cell_to_admin.size() << " cells, " << admin_polygons.size() << " polygons" << std::endl;
 
+    write_cell_index(output_dir + "/place_cells.bin", output_dir + "/place_entries.bin", cell_to_places);
+    std::cerr << "place index: " << cell_to_places.size() << " cells, " << place_points.size() << " points" << std::endl;
+
     // Street ways
     {
         std::ofstream f(output_dir + "/street_ways.bin", std::ios::binary);
@@ -840,6 +905,12 @@ static void write_index(const std::string& output_dir) {
     {
         std::ofstream f(output_dir + "/admin_vertices.bin", std::ios::binary);
         f.write(reinterpret_cast<const char*>(admin_vertices.data()), admin_vertices.size() * sizeof(NodeCoord));
+    }
+
+    // Place points
+    {
+        std::ofstream f(output_dir + "/place_points.bin", std::ios::binary);
+        f.write(reinterpret_cast<const char*>(place_points.data()), place_points.size() * sizeof(PlacePoint));
     }
 
     // Strings
@@ -920,6 +991,7 @@ int main(int argc, char* argv[]) {
     std::cerr << "  " << handler.interp_count() << " interpolation ways" << std::endl;
     std::cerr << "  " << handler.admin_count() << " admin/postcode boundaries ("
               << admin_polygons.size() << " polygon rings)" << std::endl;
+    std::cerr << "  " << handler.place_count() << " place points" << std::endl;
 
     std::cerr << "Resolving interpolation endpoints..." << std::endl;
     resolve_interpolation_endpoints();
@@ -929,6 +1001,7 @@ int main(int argc, char* argv[]) {
     deduplicate(cell_to_addrs);
     deduplicate(cell_to_interps);
     deduplicate(cell_to_admin);
+    deduplicate(cell_to_places);
 
     std::cerr << "Writing index files to " << output_dir << "..." << std::endl;
     write_index(output_dir);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -94,6 +94,12 @@ struct NodeCoord {
     lng: f32,
 }
 
+#[derive(Clone, Copy)]
+struct AdminCandidate<'a> {
+    area: f32,
+    poly: &'a AdminPolygon,
+}
+
 // --- Index data ---
 
 struct Index {
@@ -439,60 +445,67 @@ impl Index {
             )
         };
 
-        // For each admin level, find the smallest-area polygon containing the point
-        let mut best_by_level: [Option<(f32, &AdminPolygon)>; 12] = [None; 12];
+        let mut candidates_by_level: [Vec<AdminCandidate<'_>>; 12] = std::array::from_fn(|_| Vec::new());
 
-        const INTERIOR_FLAG: u32 = 0x80000000;
         const ID_MASK: u32 = 0x7FFFFFFF;
 
         for c in std::iter::once(cell).chain(neighbors.into_iter()) {
             Self::for_each_entry(&self.admin_entries, Self::lookup_offset_cell(&self.admin_cells, c), |id| {
-                let is_interior = (id & INTERIOR_FLAG) != 0;
                 let poly_id = (id & ID_MASK) as usize;
                 let poly = &all_polygons[poly_id];
                 let level = poly.admin_level as usize;
                 if level >= 12 { return; }
 
-                // Skip if we already have a smaller polygon at this level
-                if let Some((best_area, _)) = best_by_level[level] {
-                    if poly.area >= best_area { return; }
+                if !polygon_contains_point(poly, all_vertices, lat as f32, lng as f32) {
+                    return;
                 }
 
-                // Interior cells skip point-in-polygon test
-                if is_interior || point_in_polygon(lat as f32, lng as f32, {
-                    let offset = poly.vertex_offset as usize;
-                    let count = poly.vertex_count as usize;
-                    &all_vertices[offset..offset + count]
-                }) {
-                    best_by_level[level] = Some((poly.area, poly));
+                if candidates_by_level[level]
+                    .iter()
+                    .any(|candidate| std::ptr::eq(candidate.poly, poly))
+                {
+                    return;
                 }
+
+                candidates_by_level[level].push(AdminCandidate { area: poly.area, poly });
             });
         }
 
         let mut result = AdminResult::default();
+        let city = select_admin_candidate(&candidates_by_level[8], None, all_vertices);
+        let county = select_admin_candidate(&candidates_by_level[6], city, all_vertices);
+        let city_district = select_admin_candidate(&candidates_by_level[9], city, all_vertices);
+        let suburb = select_admin_candidate(&candidates_by_level[10], city.or(city_district), all_vertices);
+        let state = select_admin_candidate(&candidates_by_level[4], city.or(county), all_vertices);
+        let country = select_admin_candidate(&candidates_by_level[2], state.or(city).or(county), all_vertices);
+        let postcode = select_admin_candidate(&candidates_by_level[11], None, all_vertices);
 
-        for level in 0..12 {
-            if let Some((_, poly)) = best_by_level[level] {
-                let name = self.get_string(poly.name_id);
-                match poly.admin_level {
-                    2 => {
-                        result.country = Some(name);
-                        if poly.country_code != 0 {
-                            result.country_code = Some([
-                                (poly.country_code >> 8) as u8,
-                                (poly.country_code & 0xFF) as u8,
-                            ]);
-                        }
-                    }
-                    4 => result.state = Some(name),
-                    6 => result.county = Some(name),
-                    8 => result.city = Some(name),
-                    9 => result.city_district = Some(name),
-                    10 => result.suburb = Some(name),
-                    11 => result.postcode = Some(name),
-                    _ => {}
-                }
+        if let Some(poly) = country {
+            result.country = Some(self.get_string(poly.name_id));
+            if poly.country_code != 0 {
+                result.country_code = Some([
+                    (poly.country_code >> 8) as u8,
+                    (poly.country_code & 0xFF) as u8,
+                ]);
             }
+        }
+        if let Some(poly) = state {
+            result.state = Some(self.get_string(poly.name_id));
+        }
+        if let Some(poly) = county {
+            result.county = Some(self.get_string(poly.name_id));
+        }
+        if let Some(poly) = city {
+            result.city = Some(self.get_string(poly.name_id));
+        }
+        if let Some(poly) = city_district {
+            result.city_district = Some(self.get_string(poly.name_id));
+        }
+        if let Some(poly) = suburb {
+            result.suburb = Some(self.get_string(poly.name_id));
+        }
+        if let Some(poly) = postcode {
+            result.postcode = Some(self.get_string(poly.name_id));
         }
 
         result
@@ -683,6 +696,106 @@ fn point_to_segment_distance(
     cos_lat: f64,
 ) -> f64 {
     point_to_segment_with_t(px, py, ax, ay, bx, by, cos_lat).0
+}
+
+fn polygon_vertices<'a>(poly: &AdminPolygon, vertices: &'a [NodeCoord]) -> &'a [NodeCoord] {
+    let offset = poly.vertex_offset as usize;
+    let count = poly.vertex_count as usize;
+    &vertices[offset..offset + count]
+}
+
+fn polygon_contains_point(poly: &AdminPolygon, vertices: &[NodeCoord], lat: f32, lng: f32) -> bool {
+    point_in_polygon(lat, lng, polygon_vertices(poly, vertices))
+}
+
+fn polygon_centroid(vertices: &[NodeCoord]) -> Option<(f32, f32)> {
+    if vertices.len() < 3 {
+        return None;
+    }
+
+    let mut twice_area = 0.0f64;
+    let mut cx = 0.0f64;
+    let mut cy = 0.0f64;
+
+    for i in 0..vertices.len() {
+        let j = (i + 1) % vertices.len();
+        let cross = vertices[i].lng as f64 * vertices[j].lat as f64
+            - vertices[j].lng as f64 * vertices[i].lat as f64;
+        twice_area += cross;
+        cx += (vertices[i].lng as f64 + vertices[j].lng as f64) * cross;
+        cy += (vertices[i].lat as f64 + vertices[j].lat as f64) * cross;
+    }
+
+    if twice_area.abs() < f64::EPSILON {
+        return None;
+    }
+
+    Some(((cy / (3.0 * twice_area)) as f32, (cx / (3.0 * twice_area)) as f32))
+}
+
+fn polygon_compatibility_score(
+    candidate: &AdminPolygon,
+    child: &AdminPolygon,
+    vertices: &[NodeCoord],
+) -> usize {
+    let candidate_vertices = polygon_vertices(candidate, vertices);
+    let child_vertices = polygon_vertices(child, vertices);
+    let mut score = 0usize;
+
+    if let Some((lat, lng)) = polygon_centroid(child_vertices) {
+        if point_in_polygon(lat, lng, candidate_vertices) {
+            score += 100;
+        }
+    }
+
+    let step = (child_vertices.len() / 16).max(1);
+    for vertex in child_vertices.iter().step_by(step).take(16) {
+        if point_in_polygon(vertex.lat, vertex.lng, candidate_vertices) {
+            score += 1;
+        }
+    }
+
+    score
+}
+
+fn select_admin_candidate<'a>(
+    candidates: &[AdminCandidate<'a>],
+    child: Option<&AdminPolygon>,
+    vertices: &[NodeCoord],
+) -> Option<&'a AdminPolygon> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let mut sorted = candidates.to_vec();
+    sorted.sort_by(|a, b| a.area.total_cmp(&b.area));
+
+    if let Some(child) = child {
+        let mut best: Option<(usize, f32, &AdminPolygon)> = None;
+        for candidate in &sorted {
+            let score = polygon_compatibility_score(candidate.poly, child, vertices);
+            if score == 0 {
+                continue;
+            }
+
+            let replace = match best {
+                Some((best_score, best_area, _)) => {
+                    score > best_score || (score == best_score && candidate.area < best_area)
+                }
+                None => true,
+            };
+
+            if replace {
+                best = Some((score, candidate.area, candidate.poly));
+            }
+        }
+
+        if let Some((_, _, poly)) = best {
+            return Some(poly);
+        }
+    }
+
+    sorted.first().map(|candidate| candidate.poly)
 }
 
 // Ray casting point-in-polygon test
@@ -906,6 +1019,113 @@ fn format_address(addr: &AddressDetails<'_>) -> Option<String> {
     }
 
     if parts.is_empty() { None } else { Some(parts.join(", ")) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NAME_PERNAMBUCO: u32 = 1;
+    const NAME_PARAIBA: u32 = 2;
+    const NAME_SANTA_TEREZINHA: u32 = 3;
+
+    fn add_polygon(
+        vertices: &mut Vec<NodeCoord>,
+        points: &[(f32, f32)],
+        name_id: u32,
+        admin_level: u8,
+        area: f32,
+    ) -> AdminPolygon {
+        let vertex_offset = vertices.len() as u32;
+        vertices.extend(points.iter().map(|(lat, lng)| NodeCoord {
+            lat: *lat,
+            lng: *lng,
+        }));
+        AdminPolygon {
+            vertex_offset,
+            vertex_count: points.len() as u16,
+            name_id,
+            admin_level,
+            area,
+            country_code: 0,
+        }
+    }
+
+    #[test]
+    fn regression_border_state_prefers_pernambuco_for_santa_terezinha_coordinate() {
+        let query_lat = -7.373068f32;
+        let query_lng = -37.480312f32;
+        let mut vertices = Vec::new();
+
+        let city = add_polygon(
+            &mut vertices,
+            &[
+                (-7.3780, -37.4820),
+                (-7.3780, -37.4650),
+                (-7.3620, -37.4650),
+                (-7.3620, -37.4820),
+            ],
+            NAME_SANTA_TEREZINHA,
+            8,
+            0.001,
+        );
+        let pernambuco = add_polygon(
+            &mut vertices,
+            &[
+                (-7.5000, -37.6500),
+                (-7.5000, -37.3500),
+                (-7.2500, -37.3500),
+                (-7.2500, -37.6500),
+            ],
+            NAME_PERNAMBUCO,
+            4,
+            10.0,
+        );
+        let paraiba = add_polygon(
+            &mut vertices,
+            &[
+                (-7.3850, -37.4850),
+                (-7.3850, -37.4780),
+                (-7.3650, -37.4780),
+                (-7.3650, -37.4850),
+            ],
+            NAME_PARAIBA,
+            4,
+            0.0001,
+        );
+
+        assert!(polygon_contains_point(&city, &vertices, query_lat, query_lng));
+        assert!(polygon_contains_point(&pernambuco, &vertices, query_lat, query_lng));
+        assert!(polygon_contains_point(&paraiba, &vertices, query_lat, query_lng));
+
+        let selected_city = select_admin_candidate(
+            &[AdminCandidate {
+                area: city.area,
+                poly: &city,
+            }],
+            None,
+            &vertices,
+        )
+        .unwrap();
+        let selected_state = select_admin_candidate(
+            &[
+                AdminCandidate {
+                    area: paraiba.area,
+                    poly: &paraiba,
+                },
+                AdminCandidate {
+                    area: pernambuco.area,
+                    poly: &pernambuco,
+                },
+            ],
+            Some(selected_city),
+            &vertices,
+        )
+        .unwrap();
+
+        assert_eq!(selected_city.name_id, NAME_SANTA_TEREZINHA);
+        assert_eq!(selected_state.name_id, NAME_PERNAMBUCO);
+    }
 }
 
 #[derive(Deserialize)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -18,6 +18,14 @@ use std::sync::{Arc, RwLock};
 const DEFAULT_STREET_CELL_LEVEL: u64 = 17;
 const DEFAULT_ADMIN_CELL_LEVEL: u64 = 10;
 const DEFAULT_SEARCH_DISTANCE: f64 = 75.0;
+const PLACE_SUBURB: u8 = 1;
+const PLACE_NEIGHBOURHOOD: u8 = 2;
+const PLACE_QUARTER: u8 = 3;
+const PLACE_CITY_DISTRICT: u8 = 4;
+const PLACE_SUBURB_MAX_DISTANCE: f64 = 5_000.0;
+const PLACE_NEIGHBOURHOOD_MAX_DISTANCE: f64 = 3_000.0;
+const PLACE_QUARTER_MAX_DISTANCE: f64 = 3_000.0;
+const PLACE_CITY_DISTRICT_MAX_DISTANCE: f64 = 5_000.0;
 
 fn cell_id_at_level(lat: f64, lng: f64, level: u64) -> u64 {
     let ll = LatLng::from_degrees(lat, lng);
@@ -72,6 +80,15 @@ struct AdminPolygon {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
+struct PlacePoint {
+    lat: f32,
+    lng: f32,
+    name_id: u32,
+    place_type: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
 struct NodeCoord {
     lat: f32,
     lng: f32,
@@ -93,6 +110,9 @@ struct Index {
     admin_entries: Mmap,
     admin_polygons: Mmap,
     admin_vertices: Mmap,
+    place_cells: Option<Mmap>,
+    place_entries: Option<Mmap>,
+    place_points: Option<Mmap>,
     strings: Mmap,
     street_cell_level: u64,
     admin_cell_level: u64,
@@ -110,6 +130,22 @@ struct GeoCellOffsets {
 fn mmap_file(path: &str) -> Result<Mmap, String> {
     let file = File::open(path).map_err(|e| format!("Failed to open {}: {}", path, e))?;
     unsafe { Mmap::map(&file).map_err(|e| format!("Failed to mmap {}: {}", path, e)) }
+}
+
+fn mmap_optional_file(path: &str) -> Result<Option<Mmap>, String> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("Failed to open {}: {}", path, e)),
+    };
+    let len = file
+        .metadata()
+        .map_err(|e| format!("Failed to stat {}: {}", path, e))?
+        .len();
+    if len == 0 {
+        return Ok(None);
+    }
+    unsafe { Mmap::map(&file).map(Some).map_err(|e| format!("Failed to mmap {}: {}", path, e)) }
 }
 
 impl Index {
@@ -130,6 +166,9 @@ impl Index {
             admin_entries: mmap_file(&format!("{}/admin_entries.bin", dir))?,
             admin_polygons: mmap_file(&format!("{}/admin_polygons.bin", dir))?,
             admin_vertices: mmap_file(&format!("{}/admin_vertices.bin", dir))?,
+            place_cells: mmap_optional_file(&format!("{}/place_cells.bin", dir))?,
+            place_entries: mmap_optional_file(&format!("{}/place_entries.bin", dir))?,
+            place_points: mmap_optional_file(&format!("{}/place_points.bin", dir))?,
             strings: mmap_file(&format!("{}/strings.bin", dir))?,
             street_cell_level,
             admin_cell_level,
@@ -197,8 +236,8 @@ impl Index {
         empty
     }
 
-    // Binary search admin cell index: 12 bytes per entry (u64 cell_id + u32 offset)
-    fn lookup_admin_cell(cells: &[u8], cell_id: u64) -> u32 {
+    // Binary search cell index with a single entries offset: 12 bytes per entry (u64 cell_id + u32 offset)
+    fn lookup_offset_cell(cells: &[u8], cell_id: u64) -> u32 {
         let entry_size: usize = 12;
         let count = cells.len() / entry_size;
         if count == 0 { return NO_DATA; }
@@ -407,7 +446,7 @@ impl Index {
         const ID_MASK: u32 = 0x7FFFFFFF;
 
         for c in std::iter::once(cell).chain(neighbors.into_iter()) {
-            Self::for_each_entry(&self.admin_entries, Self::lookup_admin_cell(&self.admin_cells, c), |id| {
+            Self::for_each_entry(&self.admin_entries, Self::lookup_offset_cell(&self.admin_cells, c), |id| {
                 let is_interior = (id & INTERIOR_FLAG) != 0;
                 let poly_id = (id & ID_MASK) as usize;
                 let poly = &all_polygons[poly_id];
@@ -448,10 +487,85 @@ impl Index {
                     4 => result.state = Some(name),
                     6 => result.county = Some(name),
                     8 => result.city = Some(name),
+                    9 => result.city_district = Some(name),
+                    10 => result.suburb = Some(name),
                     11 => result.postcode = Some(name),
                     _ => {}
                 }
             }
+        }
+
+        result
+    }
+
+    fn find_places(&self, lat: f64, lng: f64) -> PlaceResult<'_> {
+        let (Some(place_cells), Some(place_entries), Some(place_points)) =
+            (&self.place_cells, &self.place_entries, &self.place_points)
+        else {
+            return PlaceResult::default();
+        };
+
+        let cell = cell_id_at_level(lat, lng, self.admin_cell_level);
+        let neighbors = cell_neighbors_at_level(cell, self.admin_cell_level);
+        let cos_lat = lat.to_radians().cos();
+
+        let all_points: &[PlacePoint] = unsafe {
+            std::slice::from_raw_parts(
+                place_points.as_ptr() as *const PlacePoint,
+                place_points.len() / std::mem::size_of::<PlacePoint>(),
+            )
+        };
+
+        let max_suburb_dist = meters_to_rad_sq(PLACE_SUBURB_MAX_DISTANCE);
+        let max_neighbourhood_dist = meters_to_rad_sq(PLACE_NEIGHBOURHOOD_MAX_DISTANCE);
+        let max_quarter_dist = meters_to_rad_sq(PLACE_QUARTER_MAX_DISTANCE);
+        let max_city_district_dist = meters_to_rad_sq(PLACE_CITY_DISTRICT_MAX_DISTANCE);
+
+        let mut result = PlaceResult::default();
+        let mut best_suburb: Option<f64> = None;
+        let mut best_neighbourhood: Option<f64> = None;
+        let mut best_quarter: Option<f64> = None;
+        let mut best_city_district: Option<f64> = None;
+
+        for c in std::iter::once(cell).chain(neighbors.into_iter()) {
+            Self::for_each_entry(place_entries, Self::lookup_offset_cell(place_cells, c), |id| {
+                let Some(point) = all_points.get(id as usize) else {
+                    return;
+                };
+
+                let dlat = (lat - point.lat as f64).to_radians();
+                let dlng = (lng - point.lng as f64).to_radians();
+                let dist = dist_sq(dlat, dlng, cos_lat);
+                let name = self.get_string(point.name_id);
+
+                match point.place_type {
+                    PLACE_SUBURB if dist <= max_suburb_dist => {
+                        if best_suburb.is_none_or(|best| dist < best) {
+                            best_suburb = Some(dist);
+                            result.suburb = Some(name);
+                        }
+                    }
+                    PLACE_NEIGHBOURHOOD if dist <= max_neighbourhood_dist => {
+                        if best_neighbourhood.is_none_or(|best| dist < best) {
+                            best_neighbourhood = Some(dist);
+                            result.neighbourhood = Some(name);
+                        }
+                    }
+                    PLACE_QUARTER if dist <= max_quarter_dist => {
+                        if best_quarter.is_none_or(|best| dist < best) {
+                            best_quarter = Some(dist);
+                            result.quarter = Some(name);
+                        }
+                    }
+                    PLACE_CITY_DISTRICT if dist <= max_city_district_dist => {
+                        if best_city_district.is_none_or(|best| dist < best) {
+                            best_city_district = Some(dist);
+                            result.city_district = Some(name);
+                        }
+                    }
+                    _ => {}
+                }
+            });
         }
 
         result
@@ -462,7 +576,8 @@ impl Index {
     fn query(&self, lat: f64, lng: f64) -> Address<'_> {
         let max_dist = self.max_distance_sq;
 
-        let admin = self.find_admin(lat, lng);
+        let mut admin = self.find_admin(lat, lng);
+        let places = self.find_places(lat, lng);
         let (addr, interp, street) = self.query_geo(lat, lng);
 
         // Pick whichever is closer: the nearest house (address point or
@@ -495,20 +610,38 @@ impl Index {
             road = Some(self.get_string(way.name_id));
         }
 
-        if road.is_none() && admin.country.is_none() && admin.city.is_none() {
-            return Address::default();
+        if admin.suburb.is_none() {
+            admin.suburb = places.suburb;
+        }
+        if admin.city_district.is_none() {
+            admin.city_district = places.city_district;
         }
 
-        let address = AddressDetails {
+        let mut address = AddressDetails {
             house_number,
             road,
             city: admin.city,
+            city_district: admin.city_district,
+            suburb: admin.suburb,
+            neighbourhood: places.neighbourhood,
+            quarter: places.quarter,
             state: admin.state,
             county: admin.county,
             postcode: admin.postcode,
             country: admin.country,
             country_code: admin.country_code.map(|c| String::from_utf8_lossy(&c).into_owned()),
         };
+        dedupe_address_details(&mut address);
+        if address.road.is_none()
+            && address.suburb.is_none()
+            && address.neighbourhood.is_none()
+            && address.quarter.is_none()
+            && address.city_district.is_none()
+            && address.country.is_none()
+            && address.city.is_none()
+        {
+            return Address::default();
+        }
         let display_name = format_address(&address);
         Address { display_name, address }
     }
@@ -582,7 +715,17 @@ struct AdminResult<'a> {
     state: Option<&'a str>,
     county: Option<&'a str>,
     city: Option<&'a str>,
+    city_district: Option<&'a str>,
+    suburb: Option<&'a str>,
     postcode: Option<&'a str>,
+}
+
+#[derive(Default)]
+struct PlaceResult<'a> {
+    city_district: Option<&'a str>,
+    suburb: Option<&'a str>,
+    neighbourhood: Option<&'a str>,
+    quarter: Option<&'a str>,
 }
 
 #[derive(Serialize, Default)]
@@ -593,6 +736,14 @@ struct AddressDetails<'a> {
     road: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     city: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    city_district: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suburb: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    neighbourhood: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quarter: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     state: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -630,8 +781,57 @@ fn format_rules(country_code: Option<&str>) -> (bool, bool, bool) {
     }
 }
 
+fn meters_to_rad_sq(meters: f64) -> f64 {
+    let meters_to_rad = meters / 111_320.0;
+    meters_to_rad * meters_to_rad
+}
+
+fn normalized_name(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+}
+
+fn names_equal(a: Option<&str>, b: Option<&str>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => normalized_name(a) == normalized_name(b),
+        _ => false,
+    }
+}
+
+fn clear_if_duplicate(value: &mut Option<&str>, others: &[Option<&str>]) {
+    if others.iter().copied().any(|other| names_equal(*value, other)) {
+        *value = None;
+    }
+}
+
+fn push_unique_part(parts: &mut Vec<String>, value: &str) {
+    if parts.iter().any(|part| normalized_name(part) == normalized_name(value)) {
+        return;
+    }
+    parts.push(value.to_string());
+}
+
+fn dedupe_address_details(addr: &mut AddressDetails<'_>) {
+    clear_if_duplicate(&mut addr.suburb, &[addr.city]);
+    clear_if_duplicate(&mut addr.neighbourhood, &[addr.city, addr.suburb]);
+    clear_if_duplicate(
+        &mut addr.quarter,
+        &[addr.city, addr.suburb, addr.neighbourhood],
+    );
+    clear_if_duplicate(
+        &mut addr.city_district,
+        &[addr.city, addr.suburb, addr.neighbourhood, addr.quarter],
+    );
+}
+
 fn format_address(addr: &AddressDetails<'_>) -> Option<String> {
-    if addr.road.is_none() && addr.city.is_none() && addr.country.is_none() {
+    if addr.road.is_none()
+        && addr.suburb.is_none()
+        && addr.neighbourhood.is_none()
+        && addr.quarter.is_none()
+        && addr.city_district.is_none()
+        && addr.city.is_none()
+        && addr.country.is_none()
+    {
         return None;
     }
 
@@ -642,13 +842,23 @@ fn format_address(addr: &AddressDetails<'_>) -> Option<String> {
     if let Some(road) = addr.road {
         if let Some(ref hn) = addr.house_number {
             if number_after {
-                parts.push(format!("{} {}", road, hn));
+                push_unique_part(&mut parts, &format!("{} {}", road, hn));
             } else {
-                parts.push(format!("{} {}", hn, road));
+                push_unique_part(&mut parts, &format!("{} {}", hn, road));
             }
         } else {
-            parts.push(road.to_string());
+            push_unique_part(&mut parts, road);
         }
+    }
+
+    if let Some(suburb) = addr.suburb {
+        push_unique_part(&mut parts, suburb);
+    } else if let Some(neighbourhood) = addr.neighbourhood {
+        push_unique_part(&mut parts, neighbourhood);
+    } else if let Some(quarter) = addr.quarter {
+        push_unique_part(&mut parts, quarter);
+    } else if let Some(city_district) = addr.city_district {
+        push_unique_part(&mut parts, city_district);
     }
 
     // City + postcode + state
@@ -668,7 +878,7 @@ fn format_address(addr: &AddressDetails<'_>) -> Option<String> {
             }
         }
         if !city_part.is_empty() {
-            parts.push(city_part.trim().to_string());
+            push_unique_part(&mut parts, city_part.trim());
         }
     } else {
         let mut city_part = String::new();
@@ -686,13 +896,13 @@ fn format_address(addr: &AddressDetails<'_>) -> Option<String> {
             city_part.push_str(pc);
         }
         if !city_part.is_empty() {
-            parts.push(city_part);
+            push_unique_part(&mut parts, &city_part);
         }
     }
 
     // Country
     if let Some(country) = addr.country {
-        parts.push(country.to_string());
+        push_unique_part(&mut parts, country);
     }
 
     if parts.is_empty() { None } else { Some(parts.join(", ")) }


### PR DESCRIPTION
## Summary

This PR improves reverse geocoding results in two related areas:

1. Exposes more detailed locality information when available.
2. Improves administrative boundary selection near border areas.

## Locality details

In some regions, OSM stores neighborhoods or local districts as:

- `boundary=administrative` with `admin_level=9` or `admin_level=10`
- `place=suburb`
- `place=neighbourhood`
- `place=quarter`
- `place=city_district`

This PR improves `/reverse` locality details by:

- mapping `admin_level=9` to `city_district`
- mapping `admin_level=10` to `suburb`
- keeping administrative boundaries as the primary source
- adding optional `place=*` fallback
- avoiding replacement of `city`, `state`, or `country`
- deduplicating locality fields when they repeat the city name
- exposing optional JSON fields:
  - `city_district`
  - `suburb`
  - `neighbourhood`
  - `quarter`
- improving `display_name` ordering to include the best available local area without duplication

Example result:

```json
{
  "display_name": "Avenida Senador Argemiro de Figueiredo, Acácio Figueiredo, Campina Grande",
  "address": {
    "road": "Avenida Senador Argemiro de Figueiredo",
    "city": "Campina Grande",
    "suburb": "Acácio Figueiredo",
    "state": "Paraíba",
    "county": "Região Metropolitana de Campina Grande"
  }
}
````

## Administrative boundary resolution near borders

This PR also fixes an issue where `/reverse` could return the wrong state near administrative borders.

Example:

```text
/reverse?lat=-7.373068&lon=-37.480312
```

Before:

```json
{
  "address": {
    "road": "Rua José Gomes de Andrade",
    "city": "Santa Terezinha",
    "state": "Paraíba",
    "country": "Brasil"
  }
}
```

Expected / after:

```json
{
  "address": {
    "road": "Rua José Gomes de Andrade",
    "city": "Santa Terezinha",
    "state": "Pernambuco",
    "country": "Brasil",
    "country_code": "BR"
  }
}
```

The same coordinate is resolved as Pernambuco by Nominatim using the same PBF source.

The issue appears to happen near administrative borders where candidates from neighboring S2 cells can compete at the same `admin_level`.

This PR improves the final candidate selection by validating administrative candidates more strictly and preferring geometrically compatible parent/child administrative areas.

## Notes

* No authentication, API key, rate-limit, or endpoint behavior changes.
* Existing indexes remain compatible for administrative-level changes.
* Reindexing is only needed to benefit from newly indexed `place=*` locality data.
* Changes are limited to:

  * `builder/src/build_index.cpp`
  * `server/src/main.rs`